### PR TITLE
Fix book card

### DIFF
--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -15,9 +15,9 @@ const BookCard = ({title, author, description, category, thumbnail_url, ISBN, bo
   return (
     <>
       <Button onClick={handleOpen}>
-        <Paper color='white' sx={{textTransform: 'none'}}>
+        <Paper color='white' sx={{textTransform: 'none', height: '250px'}}>
           <Stack direction='row'>
-            <img src={thumbnail_url} alt="" width={"200px"} style={{display: 'block', maxHeight: '270px'}} />
+            <img src={thumbnail_url} alt="" width={"200px"} style={{display: 'block', height: '250px'}} />
             <Box padding={2}>
               <Typography variant="h6" color="inherit">{title}</Typography>
               <Typography variant="subtitle2" color="inherit">By {author}</Typography>

--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -15,7 +15,7 @@ const BookCard = ({title, author, description, category, thumbnail_url, ISBN, bo
   return (
     <>
       <Button onClick={handleOpen}>
-        <Paper color='white' sx={{textTransform: 'none', height: '250px'}}>
+        <Paper color='white' sx={{textTransform: 'none', maxHeight: '250px'}}>
           <Stack direction='row'>
             <img src={thumbnail_url} alt="" width={"200px"} style={{display: 'block', height: '250px'}} />
             <Box padding={2}>

--- a/src/components/BookModal.jsx
+++ b/src/components/BookModal.jsx
@@ -41,7 +41,7 @@ const BookModal = ({open, handleClose,title, author, description, category, thum
             <Typography variant="h6" color="inherit">{title}</Typography>
             <Typography variant="subtitle2" color="inherit">By {author}</Typography>
             <Rating name="read-only" size='small' value={3} readOnly />
-            <Typography variant="body2" color="inherit" paragraph>
+            <Typography variant="body2" color="inherit" paragraph sx={{maxHeight: '150px', overflow: 'scroll', textOverflow: 'ellipsis'}}>
               {description}
             </Typography>
             <Stack direction={'row'} spacing={1}>


### PR DESCRIPTION
- Fix max height of the book card. 
- Give the image of the book card an fixed height.
- Fix the max height of the description inside the book modal. If it's bigger than the overflow should be scrollable. 